### PR TITLE
Fix compilation error by adding `template` keyword to Eigen cast calls

### DIFF
--- a/viba/single_session/Triangulation.cpp
+++ b/viba/single_session/Triangulation.cpp
@@ -135,8 +135,8 @@ void SingleSessionAdapter::refineTriangulationResult(
         continue;
       }
 
-      const Vec2 imageError = imgPt - procObs.projectionBaseRes.cast<double>();
-      const Vec2 weightedError = procObs.sqrtH_BaseRes.cast<double>() * imageError;
+      const Vec2 imageError = imgPt - procObs.projectionBaseRes.template cast<double>();
+      const Vec2 weightedError = procObs.sqrtH_BaseRes.template cast<double>() * imageError;
       const double squaredImageError = imageError.squaredNorm();
 
       if (squaredImageError < outlierSquaredThreshold) {
@@ -147,7 +147,7 @@ void SingleSessionAdapter::refineTriangulationResult(
       }
 
       const Mat23 dErr_dWorldPt =
-          procObs.sqrtH_BaseRes.cast<double>() * dImgPt_dCamPt * T_cam_world.rotationMatrix();
+          procObs.sqrtH_BaseRes.template cast<double>() * dImgPt_dCamPt * T_cam_world.rotationMatrix();
 
       const auto [softErr, dSoftErr] = loss.jet2(weightedError.squaredNorm());
       const Mat23 dLoss_dErr_dWorldPt = dSoftErr * dErr_dWorldPt;


### PR DESCRIPTION
Added the `template` keyword to `projectionBaseRes.cast<double>()` and `sqrtH_BaseRes.cast<double>()` calls to resolve https://github.com/facebookresearch/visual_inertial_bundle_adjustment/issues/6